### PR TITLE
fix: not currectly support for .NET 8.0 and .NET 9.0

### DIFF
--- a/src/AutoWire.DI/AutoWire.DI.csproj
+++ b/src/AutoWire.DI/AutoWire.DI.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>AutoWire.DI</PackageId>
-    <PackageVersion>1.0.9</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <Authors>Reza Ghadimi</Authors>
     <Description>A lightweight dependency injection library for .NET applications with automatic registration features.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -17,8 +17,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
   </ItemGroup>
 
 </Project>

--- a/tests/AutoWire.DI.Tests/ServiceRegistrations/ServiceRegistrarTests.cs
+++ b/tests/AutoWire.DI.Tests/ServiceRegistrations/ServiceRegistrarTests.cs
@@ -117,7 +117,7 @@ public class ServiceRegistrarTests
             serviceRegistrar.RegisterService(serviceType));
 
         // Ensure the exception message contains the class name
-        Assert.Contains(serviceType.FullName, exception.Message);
+        Assert.Contains(serviceType.FullName!, exception.Message);
     }
 
     [AutoInject]


### PR DESCRIPTION
- Update project file to target both .NET 8.0 and .NET 9.0 frameworks.
- Ensure compatibility and proper functionality across both versions